### PR TITLE
Update rpi.c

### DIFF
--- a/board/raspberrypi/rpi/rpi.c
+++ b/board/raspberrypi/rpi/rpi.c
@@ -289,6 +289,7 @@ static void get_board_rev(void)
 	rev_type = (revision >> 4) & 0xff;
 	models = &rpi_models_new_scheme;
 	models_count = 1;
+	model = &models[0];
 	printf("RPI %s (0x%x)\n", model->name, revision);
 	set_fdt_addr();
 	set_fdtfile();


### PR DESCRIPTION
Model is not set ( see https://github.com/u-boot/u-boot/blob/master/board/raspberrypi/rpi/rpi.c#L445-L453).
Without model, `fdtfile` env variable is set to random memory,  making `env print` unusable ...